### PR TITLE
fix: resolve the issue of frequent triggering of replaceState

### DIFF
--- a/app/components/sidebar/date-binning.ts
+++ b/app/components/sidebar/date-binning.ts
@@ -5,7 +5,7 @@ import type { ServerChatItem } from '~/lib/hooks/useChatEntries';
 type Bin = { category: string; items: ServerChatItem[] };
 
 export function binDates(_list: ServerChatItem[]) {
-  const list = _list.toSorted((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp));
+  const list = _list.slice().sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp));
 
   const binLookup: Record<string, Bin> = {};
   const bins: Array<Bin> = [];

--- a/app/lib/hooks/useChatMessage.ts
+++ b/app/lib/hooks/useChatMessage.ts
@@ -1,4 +1,5 @@
 import { useChat } from '@ai-sdk/react';
+import { useStore } from '@nanostores/react';
 import { useSearchParams } from '@remix-run/react';
 import { DefaultChatTransport, type FileUIPart } from 'ai';
 import { animate } from 'framer-motion';
@@ -10,6 +11,7 @@ import { cubicEasingFn } from '~/utils/easings';
 import { createScopedLogger } from '~/utils/logger';
 import { pagesToArtifacts } from '~/utils/page';
 import {
+  aiState,
   getChatStarted,
   setAborted,
   setChatId,
@@ -36,6 +38,7 @@ export function useChatMessage({
   const SAVE_PROJECT_DELAY_MS = 1000;
 
   const [searchParams] = useSearchParams();
+  const { chatStarted } = useStore(aiState);
   const { saveProject } = useProject();
   const { refreshUsageStats } = useChatUsage();
   const { parsedMessages, parseMessages } = useMessageParser();
@@ -89,12 +92,17 @@ export function useChatMessage({
   useEffect(() => {
     if (messages.length > 0) {
       parseMessages(messages, isLoading);
+    }
+  }, [messages, isLoading, parseMessages]);
+
+  useEffect(() => {
+    if (currentChatId && chatStarted) {
       const url = new URL(window.location.href);
       url.pathname = `/chat/${currentChatId}`;
       window.history.replaceState({}, '', url);
       setChatId(currentChatId);
     }
-  }, [messages, isLoading, parseMessages]);
+  }, [currentChatId, chatStarted]);
 
   useEffect(() => {
     if (messages.length > 0) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

当前由于每次 messages 更新时都会触发 `replaceState`，进而导致在某些浏览器，例如微信浏览器、移动端浏览器中，会抛出 `replaceState` 异常。

此 PR 优化了 `replaceState` 的次数，将只在 chatId 变化时进行处理。

#### How to test it?

测试能否正常在微信浏览器及移动端浏览器中使用。

#### Which issue(s) this PR fixes:

Fixes #4 

#### Does this PR introduce a user-facing change?
```release-note
解决在移动端或微信浏览器中使用流式输出时会报错的问题
```
